### PR TITLE
Fix/example/ragnarok

### DIFF
--- a/Sources/Ocha/Watcher.swift
+++ b/Sources/Ocha/Watcher.swift
@@ -25,6 +25,11 @@ public class Watcher {
         return stream
     }()
     
+    deinit {
+        stop()
+        release()
+    }
+
     private var _callback: FSEventStreamCallback = { (stream, contextInfo, numEvents, eventPaths, eventFlags, eventIds) in
         let watcher = unsafeBitCast(contextInfo, to: Watcher.self)
         guard let paths = unsafeBitCast(eventPaths, to: NSArray.self) as? [String] else {

--- a/Sources/OchaExample/main.swift
+++ b/Sources/OchaExample/main.swift
@@ -21,7 +21,7 @@ func ragnarok() {
         if content == formatted {
             return
         }
-        try ragnarok.exec()
+        try formatted.write(to: URL(fileURLWithPath: pathString), atomically: true, encoding: .utf8)
     } catch {
         print("[ERROR]: \(error.localizedDescription)")
         exit(1)

--- a/Sources/OchaExample/main.swift
+++ b/Sources/OchaExample/main.swift
@@ -10,7 +10,7 @@ let path = Path(#file)
 let pathString = path.absolute().string
 
 func hoge(fuga: String, piyo: Int) {
-    
+
 }
 
 func ragnarok() {
@@ -21,7 +21,11 @@ func ragnarok() {
         if content == formatted {
             return
         }
-        try formatted.write(to: URL(fileURLWithPath: pathString), atomically: true, encoding: .utf8)
+        // FIXME:  How to share file resouce practice when use xcode editor.
+        // Not immediately adapt for file changes after edited file.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            try formatted.write(to: URL(fileURLWithPath: pathString), atomically: true, encoding: .utf8)
+        }
     } catch {
         print("[ERROR]: \(error.localizedDescription)")
         exit(1)


### PR DESCRIPTION
## What
- Fix example to add delay time for adapt file changes when use xcode editor.
But, if you use other editor(e.g vim) and edit and save file. It got file changes immediately without PR changes.

### Other
Call stop and release when `deinit`.